### PR TITLE
fix: resolve Ctrl+C hanging issue in watch mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "ccstat"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccstat"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["hydai"]
 description = "Analyze Claude Code usage data from local JSONL files"


### PR DESCRIPTION
- Add graceful shutdown mechanism for file watcher thread
- Replace infinite loop with interruptible loop checking stop flag
- Properly clean up watcher resources on exit
- Bump version to 0.1.1

🤖 Generated with [Claude Code](https://claude.ai/code)