### PR TITLE
perf: add caching for cargo-tarpaulin in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,15 @@ jobs:
     - name: Run tests with all features
       run: cargo test --all-features --verbose
 
+    - name: Cache cargo-tarpaulin
+      id: cache-cargo-tarpaulin
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/bin/cargo-tarpaulin
+        key: cargo-tarpaulin-${{ runner.os }}-v1
+
     - name: Install tarpaulin
+      if: steps.cache-cargo-tarpaulin.outputs.cache-hit != 'true'
       run: cargo install cargo-tarpaulin
 
     - name: Generate coverage


### PR DESCRIPTION
Cache cargo-tarpaulin binary to avoid repeated installations on every CI run. This significantly reduces CI execution time by checking cached binary first.

🤖 Generated with [Claude Code](https://claude.ai/code)