### PR TITLE
perf: use native runners for Docker builds instead of QEMU

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,13 +16,15 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        platform:
-          - linux/amd64
-          - linux/arm64
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Prepare
         run: |
@@ -46,9 +48,6 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Replace QEMU emulation with native ARM64 and x86_64 runners:
- Use ubuntu-24.04 for linux/amd64 builds
- Use ubuntu-24.04-arm for linux/arm64 builds
- Remove docker/setup-qemu-action as it's no longer needed

This change significantly improves build performance by eliminating emulation overhead.

🤖 Generated with [Claude Code](https://claude.ai/code)