### PR TITLE
fix: add packages write permission for GitHub Container Registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,10 @@ on:
 env:
   REGISTRY_IMAGE: hydai/ccstat
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Add missing permissions block to Docker workflow to allow pushing images to ghcr.io. This resolves the "403 Forbidden - installation not allowed to Create organization package" error.

🤖 Generated with [Claude Code](https://claude.ai/code)