### PR TITLE
fix: add security-events write permission for Trivy scanner

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ env:
 permissions:
   contents: read
   packages: write
+  security-events: write
 
 jobs:
   build:


### PR DESCRIPTION
Enable CodeQL SARIF upload for security scanning results in Docker workflow

🤖 Generated with [Claude Code](https://claude.ai/code)