### PR TITLE
fix: display correct timezone in blocks command output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -284,7 +284,10 @@ async fn main() -> Result<()> {
 
             // Format and output
             let formatter = get_formatter(json, model_display_args.full_model_names);
-            println!("{}", formatter.format_sessions(&session_data, &totals));
+            println!(
+                "{}",
+                formatter.format_sessions(&session_data, &totals, &aggregator.timezone_config().tz)
+            );
         }
 
         Some(Command::Blocks {
@@ -385,7 +388,10 @@ async fn main() -> Result<()> {
 
             // Format and output
             let formatter = get_formatter(json, model_display_args.full_model_names);
-            println!("{}", formatter.format_blocks(&blocks));
+            println!(
+                "{}",
+                formatter.format_blocks(&blocks, &aggregator.timezone_config().tz)
+            );
         }
 
         Some(Command::Mcp { transport, port }) => {


### PR DESCRIPTION
The blocks command now respects the --timezone flag and displays block start times in the specified timezone, matching the behavior of daily and monthly commands.

Changes:
- Updated OutputFormatter trait to accept timezone parameter in format_blocks
- Modified TableFormatter to convert UTC times to specified timezone
- Pass timezone from aggregator to formatter in main.rs

🤖 Generated with [Claude Code](https://claude.ai/code)