### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2025-08-13
+
+### Changed
+- Major version bump to 0.2.0
+- Performance improvements and optimizations
+- Enhanced code structure for better maintainability
+
 ## [0.1.9] - 2025-08-12
 
 ### Changed
@@ -107,7 +114,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Advanced filtering options by date, project, and instance
 - High-performance stream processing with minimal memory footprint
 
-[Unreleased]: https://github.com/hydai/ccstat/compare/v0.1.9...HEAD
+[Unreleased]: https://github.com/hydai/ccstat/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/hydai/ccstat/compare/v0.1.9...v0.2.0
 [0.1.9]: https://github.com/hydai/ccstat/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/hydai/ccstat/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/hydai/ccstat/compare/v0.1.6...v0.1.7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ cargo run -- daily --project my-project
 - Example usage: `echo '{"session_id": "test", "model": {"id": "claude-3-opus", "display_name": "Claude 3 Opus"}}' | ccstat statusline`
 
 ## Important Notes
-- Current version: 0.1.9
+- Current version: 0.2.0
 - The project requires Rust 1.75 or later
 - Dependencies are managed in `ccusage/Cargo.toml`
 - Tests are co-located with source files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "ccstat"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccstat"
-version = "0.1.9"
+version = "0.2.0"
 edition = "2024"
 authors = ["hydai"]
 description = "Analyze Claude Code usage data from local JSONL files"

--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ ccstat can also be used as a Rust library. Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ccstat = "0.1.9"
+ccstat = "0.2.0"
 ```
 
 Example usage:


### PR DESCRIPTION
- Update version from 0.1.9 to 0.2.0 in Cargo.toml
- Update documentation to reflect new version
- Add CHANGELOG entry for v0.2.0 release
- Update Cargo.lock with new version

🤖 Generated with [Claude Code](https://claude.ai/code)