### PR TITLE
feat: make quiet mode default and add verbose flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CommandType enum for flexible command-specific monitoring modes
 - Enhanced LiveMonitor to support all aggregation types (daily, monthly, session, blocks)
 
+### Fixed
+- **Billing blocks --active flag regression**: Fixed issue where `ccstat blocks --active` would not show any active blocks
+  - Corrected `is_active` logic in `create_billing_blocks` to properly check if a block is within its 5-hour window
+  - Added comprehensive test coverage for active block detection
+
 ### Changed
 - **BREAKING**: Unified CLI options system - common options are now global
 - **BREAKING**: Moved `--watch` and `--interval` flags from daily command to global level

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2025-08-14
 
+### Added
+- **Live Monitoring for All Commands**: Extended `--watch` functionality to all commands
+  - `ccstat monthly --watch` - Monitor monthly aggregations in real-time
+  - `ccstat session --watch` - Watch active sessions live
+  - `ccstat blocks --watch` - Track billing blocks as they update
+  - Works with all filters and options (e.g., `--watch --project my-project`)
+- CommandType enum for flexible command-specific monitoring modes
+- Enhanced LiveMonitor to support all aggregation types (daily, monthly, session, blocks)
+
 ### Changed
 - **BREAKING**: Unified CLI options system - common options are now global
+- **BREAKING**: Moved `--watch` and `--interval` flags from daily command to global level
+- **BREAKING**: LiveMonitor::new() API signature changed to support all command types
 - All common options (json, since, until, project, etc.) can be used at the global level
 - Default to daily command when no subcommand is specified (`ccstat` = `ccstat daily`)
 - Unified date parsing to accept both YYYY-MM-DD and YYYY-MM formats
@@ -25,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Significantly reduced code duplication (~150+ lines removed)
 - More intuitive CLI usage (e.g., `ccstat --json` instead of `ccstat daily --json`)
 - Better user experience with unified options system
+- Live monitoring now available for all report types, not just daily
 
 ## [0.2.2] - 2025-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-08-14
+
+### Changed
+- **BREAKING**: Unified CLI options system - common options are now global
+- All common options (json, since, until, project, etc.) can be used at the global level
+- Default to daily command when no subcommand is specified (`ccstat` = `ccstat daily`)
+- Unified date parsing to accept both YYYY-MM-DD and YYYY-MM formats
+
+### Removed
+- **BREAKING**: Removed deprecated `--quiet` flag (quiet mode is now always the default)
+- **BREAKING**: Removed deprecated `--parallel` flag (parallel processing is always enabled)
+- **BREAKING**: Removed deprecated `load_usage_entries()` method from DataLoader
+- Removed TimezoneArgs, ModelDisplayArgs, and PerformanceArgs structs (options moved to global)
+
+### Improved
+- Significantly reduced code duplication (~150+ lines removed)
+- More intuitive CLI usage (e.g., `ccstat --json` instead of `ccstat daily --json`)
+- Better user experience with unified options system
+
 ## [0.2.2] - 2025-08-13
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,6 @@ cargo run -- blocks --active                # Active blocks only
 
 ### Global Options (work with all commands)
 - `--verbose` / `-v` - Show informational output (default is quiet mode with only warnings and errors)
-- `--quiet` / `-q` - **[DEPRECATED]** This flag no longer affects logging output and will be removed in v0.3.0. Quiet mode is now the default.
 - `--mode` - Cost calculation mode (auto, calculate, fetch, offline, none)
 - `--json` - Output results in JSON format instead of tables
 - `--since` - Filter by start date (YYYY-MM-DD or YYYY-MM format)
@@ -84,7 +83,6 @@ cargo run -- blocks --active                # Active blocks only
 - `--timezone` / `-z` - Specify timezone for date grouping (e.g., "America/New_York", "Asia/Tokyo")
 - `--utc` - Use UTC for date grouping (overrides --timezone)
 - `--full-model-names` - Show full model names instead of shortened versions
-- `--parallel` - **[DEPRECATED]** This flag has no effect and will be removed in v0.3.0. Parallel processing is always enabled.
 - `--intern` - Enable string interning for memory optimization
 - `--arena` - Enable arena allocation for parsing
 
@@ -133,10 +131,9 @@ No command-specific options. Uses all global options.
 The project includes several performance optimization features:
 
 ### Parallel Processing
-- Parallel file processing is always enabled (as of v0.2.2)
+- Parallel file processing is always enabled
 - Significantly improves performance for large datasets
 - Automatically utilizes available CPU cores
-- The `--parallel` flag is deprecated and will be removed in v0.3.0
 
 ### Memory Optimization
 - **String Interning** (`--intern`): Reduces memory usage by sharing identical strings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,27 +23,31 @@ cargo clippy --all-targets --all-features -- -D warnings
 
 ### Running the tool
 ```bash
-# Basic commands
+# Basic commands (ccstat defaults to daily command)
+cargo run                                    # Same as cargo run -- daily
 cargo run -- daily
 cargo run -- monthly
 cargo run -- session
 cargo run -- blocks
 cargo run -- statusline
-cargo run -- mcp
 
-# With timezone options
-cargo run -- daily --timezone "America/New_York"
-cargo run -- daily --utc
+# Global options can be used without a command (defaults to daily)
+cargo run -- --json                         # Daily report in JSON
+cargo run -- --since 2025-01-01             # Daily report from Jan 1
+cargo run -- --timezone "America/New_York"   # Daily report in NY timezone
 
-# With model display options
-cargo run -- daily --full-model-names
+# Global options work with all commands
+cargo run -- --json monthly                 # Monthly report in JSON
+cargo run -- --project my-project session   # Sessions for a project
 
-# With live monitoring
-cargo run -- daily --watch --interval 5
+# Date filters accept YYYY-MM-DD or YYYY-MM format
+cargo run -- --since 2025-01-01 --until 2025-01-31
+cargo run -- --since 2025-01                # From January 2025
 
-# With filters
-cargo run -- daily --since 2025-01-01 --until 2025-01-31
-cargo run -- daily --project my-project
+# Command-specific options
+cargo run -- daily --watch --interval 5     # Live monitoring
+cargo run -- daily --instances              # Per-instance breakdown
+cargo run -- blocks --active                # Active blocks only
 ```
 
 ## Project Structure
@@ -69,36 +73,34 @@ cargo run -- daily --project my-project
 
 ## Command-Line Options
 
-### Global Options
+### Global Options (work with all commands)
 - `--verbose` / `-v` - Show informational output (default is quiet mode with only warnings and errors)
 - `--quiet` / `-q` - **[DEPRECATED]** This flag no longer affects logging output and will be removed in v0.3.0. Quiet mode is now the default.
-
-### Timezone Options
+- `--mode` - Cost calculation mode (auto, calculate, fetch, offline, none)
+- `--json` - Output results in JSON format instead of tables
+- `--since` - Filter by start date (YYYY-MM-DD or YYYY-MM format)
+- `--until` - Filter by end date (YYYY-MM-DD or YYYY-MM format)
+- `--project` / `-p` - Filter by project name
 - `--timezone` / `-z` - Specify timezone for date grouping (e.g., "America/New_York", "Asia/Tokyo")
 - `--utc` - Use UTC for date grouping (overrides --timezone)
-- Default: Uses system's local timezone
-
-### Model Display Options
 - `--full-model-names` - Show full model names instead of shortened versions
-
-### Performance Options
-- `--watch` / `-w` - Enable live monitoring mode with auto-refresh
-- `--interval` - Refresh interval in seconds for watch mode (default: 5)
 - `--parallel` - **[DEPRECATED]** This flag has no effect and will be removed in v0.3.0. Parallel processing is always enabled.
 - `--intern` - Enable string interning for memory optimization
 - `--arena` - Enable arena allocation for parsing
 
-### Filtering Options
-- `--since` - Filter by start date (YYYY-MM-DD) or month (YYYY-MM)
-- `--until` - Filter by end date (YYYY-MM-DD) or month (YYYY-MM)
-- `--project` / `-p` - Filter by project name
-- `--instances` / `-i` - Show per-instance breakdown (daily command)
-
-### Output Options
-- `--json` - Output results in JSON format instead of tables
-- `--detailed` - Show detailed token information per entry (daily command only)
-
 ### Command-Specific Options
+
+#### Daily Command
+- `--instances` / `-i` - Show per-instance breakdown
+- `--watch` / `-w` - Enable live monitoring mode with auto-refresh
+- `--interval` - Refresh interval in seconds for watch mode (default: 5)
+- `--detailed` / `-d` - Show detailed token information per entry
+
+#### Monthly Command
+No command-specific options. Uses all global options.
+
+#### Session Command
+No command-specific options. Uses all global options.
 
 #### Blocks Command
 - `--active` - Show only active billing blocks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ cargo run -- daily --project my-project
 
 ### Output Options
 - `--json` - Output results in JSON format instead of tables
-- `--verbose` - Show detailed token information per entry (daily command only)
+- `--detailed` - Show detailed token information per entry (daily command only)
 
 ### Command-Specific Options
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,15 @@ cargo run -- --project my-project session   # Sessions for a project
 cargo run -- --since 2025-01-01 --until 2025-01-31
 cargo run -- --since 2025-01                # From January 2025
 
+# Live monitoring (global option, works with all commands)
+cargo run -- --watch                        # Watch daily usage (default)
+cargo run -- monthly --watch                # Watch monthly aggregations
+cargo run -- session --watch --interval 10  # Watch sessions with 10s refresh
+cargo run -- blocks --watch --active        # Watch active billing blocks
+
 # Command-specific options
-cargo run -- daily --watch --interval 5     # Live monitoring
 cargo run -- daily --instances              # Per-instance breakdown
+cargo run -- daily --detailed               # Show detailed token info
 cargo run -- blocks --active                # Active blocks only
 ```
 
@@ -75,6 +81,8 @@ cargo run -- blocks --active                # Active blocks only
 
 ### Global Options (work with all commands)
 - `--verbose` / `-v` - Show informational output (default is quiet mode with only warnings and errors)
+- `--watch` / `-w` - Enable live monitoring mode with auto-refresh (works with all commands)
+- `--interval` - Refresh interval in seconds for watch mode (default: 5)
 - `--mode` - Cost calculation mode (auto, calculate, fetch, offline, none)
 - `--json` - Output results in JSON format instead of tables
 - `--since` - Filter by start date (YYYY-MM-DD or YYYY-MM format)
@@ -90,8 +98,6 @@ cargo run -- blocks --active                # Active blocks only
 
 #### Daily Command
 - `--instances` / `-i` - Show per-instance breakdown
-- `--watch` / `-w` - Enable live monitoring mode with auto-refresh
-- `--interval` - Refresh interval in seconds for watch mode (default: 5)
 - `--detailed` / `-d` - Show detailed token information per entry
 
 #### Monthly Command
@@ -117,7 +123,7 @@ No command-specific options. Uses all global options.
 - Example usage: `echo '{"session_id": "test", "model": {"id": "claude-3-opus", "display_name": "Claude 3 Opus"}}' | ccstat statusline`
 
 ## Important Notes
-- Current version: 0.2.2
+- Current version: 0.3.0
 - The project requires Rust 1.75 or later
 - Dependencies are managed in `ccusage/Cargo.toml`
 - Tests are co-located with source files
@@ -142,9 +148,10 @@ The project includes several performance optimization features:
 - **Stream Processing**: Processes data in chunks to minimize memory footprint
 
 ### Live Monitoring
-- Use `--watch` flag for real-time updates
+- Use `--watch` flag for real-time updates with ALL commands (daily, monthly, session, blocks)
 - Configurable refresh interval with `--interval`
 - Optimized for minimal CPU and memory usage during monitoring
+- Automatically refreshes when data files change or at specified intervals
 
 ### Statusline Performance
 - Optimized specifically for Claude Code integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ cargo run -- daily --project my-project
 
 ### Global Options
 - `--verbose` / `-v` - Show informational output (default is quiet mode with only warnings and errors)
-- `--quiet` / `-q` - **[DEPRECATED]** This flag has no effect and will be removed in v0.3.0. Quiet mode is now the default.
+- `--quiet` / `-q` - **[DEPRECATED]** This flag no longer affects logging output and will be removed in v0.3.0. Quiet mode is now the default.
 
 ### Timezone Options
 - `--timezone` / `-z` - Specify timezone for date grouping (e.g., "America/New_York", "Asia/Tokyo")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,8 @@ cargo run -- daily --project my-project
 ## Command-Line Options
 
 ### Global Options
-- `--quiet` / `-q` - Suppress informational output (only show warnings and errors)
+- `--verbose` / `-v` - Show informational output (default is quiet mode with only warnings and errors)
+- `--quiet` / `-q` - **[DEPRECATED]** This flag has no effect and will be removed in v0.3.0. Quiet mode is now the default.
 
 ### Timezone Options
 - `--timezone` / `-z` - Specify timezone for date grouping (e.g., "America/New_York", "Asia/Tokyo")
@@ -95,7 +96,7 @@ cargo run -- daily --project my-project
 
 ### Output Options
 - `--json` - Output results in JSON format instead of tables
-- `--verbose` / `-v` - Show detailed token information per entry
+- `--verbose` - Show detailed token information per entry (daily command only)
 
 ### Command-Specific Options
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "ccstat"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccstat"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 authors = ["hydai"]
 description = "Analyze Claude Code usage data from local JSONL files"

--- a/README.md
+++ b/README.md
@@ -87,8 +87,11 @@ The Docker image is multi-platform and supports both `linux/amd64` and `linux/ar
 ## Quick Start
 
 ```bash
-# View today's usage
+# View today's usage (quiet by default)
 ccstat daily
+
+# View with informational messages
+ccstat daily --verbose
 
 # View this month's usage
 ccstat monthly
@@ -144,7 +147,7 @@ ccstat daily --parallel       # [DEPRECATED] This flag has no effect (will be re
 ccstat daily --intern         # Use string interning for memory efficiency
 ccstat daily --arena          # Use arena allocation
 
-# Verbose mode (show detailed token info per entry)
+# Show detailed token info per entry
 ccstat daily --verbose
 ```
 
@@ -369,6 +372,13 @@ ccstat daily --intern --arena
 
 - `CLAUDE_DATA_PATH`: Override default Claude data directory location
 - `RUST_LOG`: Control logging level (e.g., `RUST_LOG=ccstat=debug`)
+
+### Logging Behavior
+
+Starting from v0.2.3, ccstat runs in quiet mode by default (only warnings and errors are shown):
+- Use `--verbose` or `-v` flag to show informational messages
+- The `--quiet` flag is deprecated and will be removed in v0.3.0 (quiet is now the default)
+- `RUST_LOG` environment variable can override these defaults
 
 ### Data Locations
 

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ The Docker image is multi-platform and supports both `linux/amd64` and `linux/ar
 ## Quick Start
 
 ```bash
-# View today's usage (quiet by default)
-ccstat daily
+# View today's usage (defaults to daily command)
+ccstat
 
 # View with informational messages
-ccstat daily --verbose
+ccstat --verbose
 
 # View this month's usage
 ccstat monthly
@@ -102,53 +102,45 @@ ccstat session
 # Show statusline for Claude Code integration
 ccstat statusline
 
-# Export data as JSON for further processing
-ccstat daily --json > usage.json
+# Export data as JSON for further processing (global option)
+ccstat --json > usage.json
 ```
 
 ## Usage
 
 ### Daily Usage Report
 
-Show daily token usage and costs:
+Show daily token usage and costs. The daily command is the default when no command is specified.
 
 ```bash
-# Default table output
+# Default table output (these are equivalent)
+ccstat
 ccstat daily
 
-# JSON output for processing
-ccstat daily --json
+# Common options can be used globally or with commands
+ccstat --json                               # JSON output (global)
+ccstat daily --json                         # JSON output (command-specific, backward compatible)
 
-# Filter by date range
-ccstat daily --since 2024-01-01 --until 2024-01-31
+# Filter by date range (accepts YYYY-MM-DD or YYYY-MM format)
+ccstat --since 2024-01-01 --until 2024-01-31
+ccstat --since 2024-01                      # From January 2024
 
-# Show per-instance breakdown
-ccstat daily --instances
+# Daily-specific options
+ccstat daily --instances                    # Show per-instance breakdown
+ccstat daily --watch                        # Live monitoring mode
+ccstat daily --watch --interval 30          # Custom refresh interval
+ccstat daily --detailed                     # Show detailed token info
 
-# Filter by project
-ccstat daily --project my-project
+# Global options work with all commands
+ccstat --project my-project                 # Filter by project
+ccstat --timezone "America/New_York"        # Use specific timezone
+ccstat --utc                                # Force UTC timezone
+ccstat --full-model-names                   # Show full model names
 
-# Timezone configuration
-ccstat daily --timezone "America/New_York"  # Use specific timezone
-ccstat daily --utc                          # Force UTC timezone
-
-# Model display options
-ccstat daily --full-model-names             # Show full model names
-
-# Live monitoring mode (auto-refresh)
-ccstat daily --watch
-
-# Custom refresh interval (seconds)
-ccstat daily --watch --interval 30
-
-# Performance options
-ccstat daily                  # Parallel processing is always enabled
-ccstat daily --parallel       # [DEPRECATED] This flag has no effect (will be removed in v0.3.0)
-ccstat daily --intern         # Use string interning for memory efficiency
-ccstat daily --arena          # Use arena allocation
-
-# Show detailed token info per entry
-ccstat daily --detailed
+# Performance options (global)
+ccstat --intern                             # Use string interning
+ccstat --arena                              # Use arena allocation
+ccstat --parallel                           # [DEPRECATED] Has no effect
 ```
 
 ### Monthly Summary
@@ -159,8 +151,9 @@ Aggregate usage by month:
 # Monthly totals
 ccstat monthly
 
-# Filter specific months
-ccstat monthly --since 2024-01 --until 2024-03
+# Filter specific months (accepts YYYY-MM-DD or YYYY-MM format)
+ccstat monthly --since 2024-01-01 --until 2024-03-31
+ccstat monthly --since 2024-01 --until 2024-03  # Also works
 
 # JSON output
 ccstat monthly --json

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ ccstat daily --intern         # Use string interning for memory efficiency
 ccstat daily --arena          # Use arena allocation
 
 # Show detailed token info per entry
-ccstat daily --verbose
+ccstat daily --detailed
 ```
 
 ### Monthly Summary
@@ -257,19 +257,19 @@ ccstat daily --mode calculate
 ccstat daily --mode display
 ```
 
-### Verbose Mode
+### Detailed Output Mode
 
 Get detailed token information for each API call:
 
 ```bash
 # Show individual entries for daily usage
-ccstat daily --verbose
+ccstat daily --detailed
 
-# Verbose mode with JSON output
-ccstat daily --verbose --json
+# Detailed mode with JSON output
+ccstat daily --detailed --json
 
-# Verbose mode for specific date
-ccstat daily --verbose --since 2024-01-15 --until 2024-01-15
+# Detailed mode for specific date
+ccstat daily --detailed --since 2024-01-15 --until 2024-01-15
 ```
 
 ### Statusline Command

--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ ccstat --full-model-names                   # Show full model names
 # Performance options (global)
 ccstat --intern                             # Use string interning
 ccstat --arena                              # Use arena allocation
-ccstat --parallel                           # [DEPRECATED] Has no effect
 ```
 
 ### Monthly Summary
@@ -309,8 +308,6 @@ ccstat daily --arena
 
 # Combine all optimizations
 ccstat daily --intern --arena
-
-# Note: --parallel flag is deprecated and has no effect (will be removed in v0.3.0)
 ```
 
 ## Output Examples
@@ -368,9 +365,8 @@ ccstat daily --intern --arena
 
 ### Logging Behavior
 
-Starting from v0.2.3, ccstat runs in quiet mode by default (only warnings and errors are shown):
+ccstat runs in quiet mode by default (only warnings and errors are shown):
 - Use `--verbose` or `-v` flag to show informational messages
-- The `--quiet` flag is deprecated and will be removed in v0.3.0 (quiet is now the default)
 - `RUST_LOG` environment variable can override these defaults
 
 ### Data Locations
@@ -489,7 +485,6 @@ The project follows a modular architecture:
 - Parallel processing is always enabled for better performance
 - Use `--intern` flag to reduce memory usage for repeated strings
 - Use `--arena` flag for more efficient memory allocation
-- Note: The `--parallel` flag is deprecated and will be removed in v0.3.0
 
 ### Debug Mode
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This project is inspired by [ccusage](https://github.com/ryoppippi/ccusage) and 
 - 🔍 **Automatic Discovery**: Finds Claude data directories across platforms
 - 📈 **Flexible Output**: Table format for humans, JSON for machines
 - 🚀 **High Performance**: Stream processing with minimal memory footprint
-- 👀 **Live Monitoring**: Real-time usage tracking with auto-refresh
+- 👀 **Universal Live Monitoring**: Real-time tracking with auto-refresh for ALL commands
 - ⚡ **Performance Options**: Parallel processing, string interning, arena allocation
 - 🔧 **Advanced Filtering**: By date, project, instance, and more
 - 🌍 **Timezone Support**: Accurate daily aggregation across different timezones
@@ -104,6 +104,12 @@ ccstat statusline
 
 # Export data as JSON for further processing (global option)
 ccstat --json > usage.json
+
+# Live monitoring (works with all commands)
+ccstat --watch                    # Watch daily usage (default)
+ccstat monthly --watch            # Watch monthly aggregations
+ccstat session --watch            # Watch active sessions
+ccstat blocks --watch --active    # Watch active billing blocks
 ```
 
 ## Usage
@@ -127,9 +133,11 @@ ccstat --since 2024-01                      # From January 2024
 
 # Daily-specific options
 ccstat daily --instances                    # Show per-instance breakdown
-ccstat daily --watch                        # Live monitoring mode
-ccstat daily --watch --interval 30          # Custom refresh interval
 ccstat daily --detailed                     # Show detailed token info
+
+# Live monitoring (global option, works with all commands)
+ccstat --watch                              # Watch daily usage (default)
+ccstat --watch --interval 30                # Custom refresh interval
 
 # Global options work with all commands
 ccstat --project my-project                 # Filter by project
@@ -154,14 +162,15 @@ ccstat monthly
 ccstat monthly --since 2024-01-01 --until 2024-03-31
 ccstat monthly --since 2024-01 --until 2024-03  # Also works
 
+# Live monitoring
+ccstat monthly --watch                      # Watch monthly aggregations
+ccstat monthly --watch --interval 10        # Custom refresh interval
+
 # JSON output
 ccstat monthly --json
 
 # Filter by project
 ccstat monthly --project my-project
-
-# Show per-instance breakdown
-ccstat monthly --instances
 
 # Timezone configuration
 ccstat monthly --timezone "Asia/Tokyo"      # Use specific timezone
@@ -179,6 +188,10 @@ Analyze individual sessions:
 # List all sessions
 ccstat session
 
+# Live monitoring
+ccstat session --watch                      # Watch active sessions
+ccstat session --watch --interval 5         # Refresh every 5 seconds
+
 # JSON output with full details
 ccstat session --json
 
@@ -187,9 +200,6 @@ ccstat session --since 2024-01-01 --until 2024-01-31
 
 # Filter by project
 ccstat session --project my-project
-
-# Show detailed models per session
-ccstat session --models
 
 # Timezone configuration
 ccstat session --timezone "Europe/London"   # Use specific timezone
@@ -210,6 +220,11 @@ Track 5-hour billing blocks:
 ```bash
 # Show all blocks
 ccstat blocks
+
+# Live monitoring
+ccstat blocks --watch                       # Watch billing blocks update
+ccstat blocks --watch --active              # Watch only active blocks
+ccstat blocks --watch --interval 10         # Custom refresh interval
 
 # Only active blocks
 ccstat blocks --active

--- a/USAGE.md
+++ b/USAGE.md
@@ -57,7 +57,6 @@ ccstat daily [OPTIONS]
 - `--project <NAME>`: Filter by project name
 - `--mode <MODE>`: Cost calculation mode (auto/calculate/display)
 - `--verbose`: Show individual API calls
-- `--parallel`: [DEPRECATED] This flag has no effect (will be removed in v0.3.0)
 - `--intern`: Use string interning
 - `--arena`: Use arena allocation
 - `--by-instance`: Group by instance ID
@@ -79,8 +78,6 @@ ccstat daily --verbose
 
 # Optimized for large datasets (parallel is always enabled)
 ccstat daily --intern --arena
-
-# Note: --parallel flag is deprecated and has no effect
 ```
 
 ### Monthly Command
@@ -364,7 +361,6 @@ A: Use the optimization flags:
 - Parallel processing is always enabled (as of v0.2.2)
 - `--intern`: Deduplicate strings in memory
 - `--arena`: Use arena allocation for better memory layout
-- Note: The `--parallel` flag is deprecated and will be removed in v0.3.0
 
 ### Q: Can I use ccstat in scripts?
 

--- a/scripts/cross-platform-test.ps1
+++ b/scripts/cross-platform-test.ps1
@@ -107,9 +107,9 @@ Test-Command "String interning" "ccstat daily --intern"
 Test-Command "Arena allocation" "ccstat daily --arena"
 Test-Command "All performance flags" "ccstat daily --parallel --intern --arena"
 
-# Test verbose mode
-Write-Host "`n=== Verbose Mode Tests ===" -ForegroundColor Yellow
-Test-Command "Verbose daily output" "ccstat daily --verbose --since 2024-01-01 --until 2024-01-01"
+# Test detailed mode
+Write-Host "`n=== Detailed Mode Tests ===" -ForegroundColor Yellow
+Test-Command "Detailed daily output" "ccstat daily --detailed --since 2024-01-01 --until 2024-01-01"
 
 # Test project filtering
 Write-Host "`n=== Project Filter Tests ===" -ForegroundColor Yellow

--- a/scripts/cross-platform-test.ps1
+++ b/scripts/cross-platform-test.ps1
@@ -102,10 +102,9 @@ Test-Command "Display cost mode" "ccstat daily --mode display"
 
 # Test performance flags
 Write-Host "`n=== Performance Flag Tests ===" -ForegroundColor Yellow
-Test-Command "Parallel processing" "ccstat daily --parallel"
 Test-Command "String interning" "ccstat daily --intern"
 Test-Command "Arena allocation" "ccstat daily --arena"
-Test-Command "All performance flags" "ccstat daily --parallel --intern --arena"
+Test-Command "All performance flags" "ccstat daily --intern --arena"
 
 # Test detailed mode
 Write-Host "`n=== Detailed Mode Tests ===" -ForegroundColor Yellow

--- a/scripts/cross-platform-test.sh
+++ b/scripts/cross-platform-test.sh
@@ -98,10 +98,9 @@ run_test "Invalid cost mode" "ccstat daily --mode invalid" "Invalid value" || tr
 
 # Test performance flags
 echo -e "\n=== Performance Flag Tests ==="
-run_test "Parallel processing" "ccstat daily --parallel" ""
 run_test "String interning" "ccstat daily --intern" ""
 run_test "Arena allocation" "ccstat daily --arena" ""
-run_test "All performance flags" "ccstat daily --parallel --intern --arena" ""
+run_test "All performance flags" "ccstat daily --intern --arena" ""
 
 # Test detailed mode
 echo -e "\n=== Detailed Mode Tests ==="

--- a/scripts/cross-platform-test.sh
+++ b/scripts/cross-platform-test.sh
@@ -103,9 +103,9 @@ run_test "String interning" "ccstat daily --intern" ""
 run_test "Arena allocation" "ccstat daily --arena" ""
 run_test "All performance flags" "ccstat daily --parallel --intern --arena" ""
 
-# Test verbose mode
-echo -e "\n=== Verbose Mode Tests ==="
-run_test "Verbose daily output" "ccstat daily --verbose --since 2024-01-01 --until 2024-01-01" ""
+# Test detailed mode
+echo -e "\n=== Detailed Mode Tests ==="
+run_test "Detailed daily output" "ccstat daily --detailed --since 2024-01-01 --until 2024-01-01" ""
 
 # Test project filtering
 echo -e "\n=== Project Filter Tests ==="

--- a/scripts/memory-test.sh
+++ b/scripts/memory-test.sh
@@ -88,7 +88,7 @@ run_stress_test() {
     export CLAUDE_DATA_PATH=stress-test-data
     for i in {1..10}; do
         echo -n "Run $i: "
-        ccstat daily --parallel --intern --arena > /dev/null 2>&1
+        ccstat daily --intern --arena > /dev/null 2>&1
 
         # Check memory after each run
         if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -181,7 +181,7 @@ run_valgrind_test "daily" "target/release/ccstat daily"
 run_valgrind_test "monthly" "target/release/ccstat monthly"
 run_valgrind_test "session" "target/release/ccstat session"
 run_valgrind_test "blocks" "target/release/ccstat blocks"
-run_valgrind_test "parallel" "target/release/ccstat daily --parallel --intern --arena"
+run_valgrind_test "performance" "target/release/ccstat daily --intern --arena"
 
 # Run stress test
 run_stress_test

--- a/src/aggregation.rs
+++ b/src/aggregation.rs
@@ -711,6 +711,15 @@ impl Totals {
         }
         totals
     }
+
+    pub fn from_blocks(blocks: &[SessionBlock]) -> Self {
+        let mut totals = Self::default();
+        for block in blocks {
+            totals.tokens += block.tokens;
+            totals.total_cost += block.total_cost;
+        }
+        totals
+    }
 }
 
 #[cfg(test)]

--- a/src/aggregation.rs
+++ b/src/aggregation.rs
@@ -245,12 +245,12 @@ struct DailyAccumulator {
 }
 
 impl DailyAccumulator {
-    fn new(verbose: bool) -> Self {
+    fn new(detailed: bool) -> Self {
         Self {
             tokens: TokenCounts::default(),
             cost: 0.0,
             models: HashSet::new(),
-            verbose_entries: if verbose { Some(Vec::new()) } else { None },
+            verbose_entries: if detailed { Some(Vec::new()) } else { None },
         }
     }
 
@@ -440,12 +440,12 @@ impl Aggregator {
             .await
     }
 
-    /// Aggregate entries by day with optional verbose mode
+    /// Aggregate entries by day with optional detailed mode
     pub async fn aggregate_daily_verbose(
         &self,
         entries: impl Stream<Item = Result<UsageEntry>>,
         cost_mode: CostMode,
-        verbose: bool,
+        detailed: bool,
     ) -> Result<Vec<DailyUsage>> {
         let mut daily_map: BTreeMap<DailyDate, DailyAccumulator> = BTreeMap::new();
 
@@ -480,7 +480,7 @@ impl Aggregator {
 
             daily_map
                 .entry(date)
-                .or_insert_with(|| DailyAccumulator::new(verbose))
+                .or_insert_with(|| DailyAccumulator::new(detailed))
                 .add_entry(&entry, cost);
 
             count += 1;

--- a/src/aggregation.rs
+++ b/src/aggregation.rs
@@ -436,12 +436,12 @@ impl Aggregator {
         entries: impl Stream<Item = Result<UsageEntry>>,
         cost_mode: CostMode,
     ) -> Result<Vec<DailyUsage>> {
-        self.aggregate_daily_verbose(entries, cost_mode, false)
+        self.aggregate_daily_detailed(entries, cost_mode, false)
             .await
     }
 
     /// Aggregate entries by day with optional detailed mode
-    pub async fn aggregate_daily_verbose(
+    pub async fn aggregate_daily_detailed(
         &self,
         entries: impl Stream<Item = Result<UsageEntry>>,
         cost_mode: CostMode,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -287,6 +287,25 @@ impl Command {
             Self::Statusline { .. } => false,
         }
     }
+
+    /// Get performance args if the command has them
+    pub fn performance_args(&self) -> Option<&PerformanceArgs> {
+        match self {
+            Self::Daily {
+                performance_args, ..
+            }
+            | Self::Monthly {
+                performance_args, ..
+            }
+            | Self::Session {
+                performance_args, ..
+            }
+            | Self::Blocks {
+                performance_args, ..
+            } => Some(performance_args),
+            Self::Statusline { .. } => None,
+        }
+    }
 }
 
 /// Parse date filter from string

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,7 +37,7 @@ pub struct Cli {
         long,
         short = 'q',
         global = true,
-        help = "[DEPRECATED] This flag has no effect. Quiet mode is now the default. Use --verbose to show informational output."
+        help = "[DEPRECATED] This flag no longer affects logging output. Quiet mode is now the default. Use --verbose to show informational output."
     )]
     pub quiet: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,9 +32,18 @@ use clap::{Parser, Subcommand};
 #[command(name = "ccstat")]
 #[command(version, about, long_about = None)]
 pub struct Cli {
-    /// Suppress informational output (only show warnings and errors)
-    #[arg(long, short = 'q', global = true)]
+    /// \[DEPRECATED\] This flag is deprecated and will be removed in v0.3.0. Quiet mode is now the default behavior.
+    #[arg(
+        long,
+        short = 'q',
+        global = true,
+        help = "[DEPRECATED] This flag has no effect. Quiet mode is now the default. Use --verbose to show informational output."
+    )]
     pub quiet: bool,
+
+    /// Show informational output (default is quiet mode with only warnings and errors)
+    #[arg(long, short = 'v', global = true)]
+    pub verbose: bool,
 
     /// Subcommand to execute
     #[command(subcommand)]
@@ -123,7 +132,7 @@ pub enum Command {
         interval: u64,
 
         /// Show detailed token information per entry
-        #[arg(long, short = 'v')]
+        #[arg(long)]
         verbose: bool,
 
         /// Performance options

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -133,7 +133,7 @@ pub enum Command {
 
         /// Show detailed token information per entry
         #[arg(long)]
-        verbose: bool,
+        detailed: bool,
 
         /// Performance options
         #[command(flatten)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,6 +77,14 @@ pub struct Cli {
     #[arg(long, global = true)]
     pub arena: bool,
 
+    /// Enable live monitoring mode (auto-refresh on changes)
+    #[arg(long, short = 'w', global = true)]
+    pub watch: bool,
+
+    /// Refresh interval in seconds for watch mode (default: 5)
+    #[arg(long, default_value = "5", global = true)]
+    pub interval: u64,
+
     /// Subcommand to execute
     #[command(subcommand)]
     pub command: Option<Command>,
@@ -93,14 +101,6 @@ pub enum Command {
         /// Show per-instance breakdown
         #[arg(long, short = 'i')]
         instances: bool,
-
-        /// Enable live monitoring mode
-        #[arg(long, short = 'w')]
-        watch: bool,
-
-        /// Refresh interval in seconds (default: 5)
-        #[arg(long, default_value = "5")]
-        interval: u64,
 
         /// Show detailed token information per entry
         #[arg(long, short = 'd')]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,7 +103,7 @@ pub enum Command {
         instances: bool,
 
         /// Show detailed token information per entry
-        #[arg(long, short = 'd')]
+        #[arg(long, short = 'd', conflicts_with = "instances")]
         detailed: bool,
     },
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,15 +32,6 @@ use clap::{Parser, Subcommand};
 #[command(name = "ccstat")]
 #[command(version, about, long_about = None)]
 pub struct Cli {
-    /// \[DEPRECATED\] This flag is deprecated and will be removed in v0.3.0. Quiet mode is now the default behavior.
-    #[arg(
-        long,
-        short = 'q',
-        global = true,
-        help = "[DEPRECATED] This flag no longer affects logging output. Quiet mode is now the default. Use --verbose to show informational output."
-    )]
-    pub quiet: bool,
-
     /// Show informational output (default is quiet mode with only warnings and errors)
     #[arg(long, short = 'v', global = true)]
     pub verbose: bool,
@@ -77,15 +68,6 @@ pub struct Cli {
     /// Show full model names instead of shortened versions
     #[arg(long, global = true)]
     pub full_model_names: bool,
-
-    /// \[DEPRECATED\] This flag is deprecated and will be removed in v0.3.0. Parallel processing is now always enabled.
-    #[arg(
-        long,
-        default_value_t = true,
-        global = true,
-        help = "[DEPRECATED] This flag has no effect. Parallel processing is always enabled."
-    )]
-    pub parallel: bool,
 
     /// Enable string interning for memory optimization
     #[arg(long, global = true)]

--- a/src/data_loader.rs
+++ b/src/data_loader.rs
@@ -528,44 +528,6 @@ impl DataLoader {
         }
     }
 
-    /// Load usage entries as an async stream
-    ///
-    /// **DEPRECATED**: This method now internally calls `load_usage_entries_parallel()`.
-    /// Direct use of `load_usage_entries_parallel()` is recommended.
-    /// This method will be removed in v0.3.0.
-    ///
-    /// # Returns
-    ///
-    /// An async stream of `Result<UsageEntry>` items
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # use ccstat::data_loader::DataLoader;
-    /// # use futures::StreamExt;
-    /// # async fn example() -> ccstat::Result<()> {
-    /// let loader = DataLoader::new().await?;
-    /// let entries = loader.load_usage_entries();
-    /// tokio::pin!(entries);
-    ///
-    /// while let Some(entry) = entries.next().await {
-    ///     match entry {
-    ///         Ok(usage) => println!("Loaded entry for session {}", usage.session_id),
-    ///         Err(e) => eprintln!("Error loading entry: {}", e),
-    ///     }
-    /// }
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[deprecated(
-        since = "0.2.2",
-        note = "Use load_usage_entries_parallel() instead. This method now internally calls load_usage_entries_parallel()."
-    )]
-    pub fn load_usage_entries(&self) -> impl Stream<Item = Result<UsageEntry>> + '_ {
-        // Now just calls the parallel version
-        self.load_usage_entries_parallel()
-    }
-
     /// Parse a single JSONL file as a stream
     fn parse_jsonl_stream<'a>(
         &'a self,

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,10 @@ pub enum CcstatError {
     #[error("Invalid timezone: {0}")]
     InvalidTimezone(String),
 
+    /// Invalid token limit
+    #[error("Invalid token limit: {0}")]
+    InvalidTokenLimit(String),
+
     /// Parse error with file context
     #[error("Parse error in {file}: {error}")]
     Parse {

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,14 +41,18 @@ async fn init_data_loader(
         .with_arena(perf_args.arena))
 }
 
-/// Helper function to check for deprecated flags and show warnings
-fn check_deprecated_flags(quiet: bool, perf_args: &ccstat::cli::PerformanceArgs) {
-    if quiet {
+/// Helper function to check for deprecated global flags and show warnings
+fn check_deprecated_global_flags(cli: &Cli) {
+    if cli.quiet {
         eprintln!("Warning: --quiet flag is deprecated and will be removed in v0.3.0");
         eprintln!(
             "         Quiet mode is now the default behavior. Use --verbose to show informational output."
         );
     }
+}
+
+/// Helper function to check for deprecated command-specific flags and show warnings
+fn check_deprecated_perf_flags(perf_args: &ccstat::cli::PerformanceArgs) {
     if !perf_args.parallel {
         eprintln!("Warning: --parallel=false flag is deprecated and will be removed in v0.3.0");
         eprintln!("         Parallel processing is now always enabled for better performance.");
@@ -59,6 +63,9 @@ fn check_deprecated_flags(quiet: bool, perf_args: &ccstat::cli::PerformanceArgs)
 async fn main() -> Result<()> {
     // Parse CLI arguments first to check for quiet flag
     let cli = Cli::parse();
+
+    // Check for deprecated global flags early
+    check_deprecated_global_flags(&cli);
 
     // Skip logging initialization for statusline command
     let is_statusline = matches!(cli.command, Some(Command::Statusline { .. }));
@@ -93,7 +100,7 @@ async fn main() -> Result<()> {
             timezone_args,
         }) => {
             info!("Running daily usage report");
-            check_deprecated_flags(cli.quiet, &performance_args);
+            check_deprecated_perf_flags(&performance_args);
 
             // Initialize components with progress bars enabled for terminal output
             let show_progress = !json && !watch && is_terminal::is_terminal(std::io::stdout());
@@ -176,7 +183,7 @@ async fn main() -> Result<()> {
             timezone_args,
         }) => {
             info!("Running monthly usage report");
-            check_deprecated_flags(cli.quiet, &performance_args);
+            check_deprecated_perf_flags(&performance_args);
 
             // Initialize components with progress bars enabled for terminal output
             let show_progress = !json && is_terminal::is_terminal(std::io::stdout());
@@ -241,7 +248,7 @@ async fn main() -> Result<()> {
             timezone_args,
         }) => {
             info!("Running session usage report");
-            check_deprecated_flags(cli.quiet, &performance_args);
+            check_deprecated_perf_flags(&performance_args);
 
             // Initialize components with progress bars enabled for terminal output
             let show_progress = !json && is_terminal::is_terminal(std::io::stdout());
@@ -292,7 +299,7 @@ async fn main() -> Result<()> {
             timezone_args,
         }) => {
             info!("Running billing blocks report");
-            check_deprecated_flags(cli.quiet, &performance_args);
+            check_deprecated_perf_flags(&performance_args);
 
             // Initialize components with progress bars enabled for terminal output
             let show_progress = !json && is_terminal::is_terminal(std::io::stdout());

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,11 +131,7 @@ async fn main() -> Result<()> {
                 // Apply month filter to aggregated monthly data
                 filter_monthly_data(&mut monthly_data, &month_filter);
 
-                let mut totals = Totals::default();
-                for monthly in &monthly_data {
-                    totals.tokens += monthly.tokens;
-                    totals.total_cost += monthly.total_cost;
-                }
+                let totals = Totals::from_monthly(&monthly_data);
 
                 // Format and output
                 let formatter = get_formatter(cli.json, cli.full_model_names);

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,13 +66,9 @@ async fn main() -> Result<()> {
     if !is_statusline {
         // Initialize logging. Default is quiet (warn level), --verbose enables info level.
         // RUST_LOG environment variable can override these defaults.
-        let filter = if cli.verbose {
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("ccstat=info"))
-        } else {
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"))
-        };
+        let default_level = if cli.verbose { "ccstat=info" } else { "warn" };
+        let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new(default_level));
 
         tracing_subscriber::registry()
             .with(filter)
@@ -91,7 +87,7 @@ async fn main() -> Result<()> {
             project,
             watch,
             interval,
-            verbose,
+            detailed,
             performance_args,
             model_display_args,
             timezone_args,
@@ -161,7 +157,7 @@ async fn main() -> Result<()> {
                     let entries = Box::pin(data_loader.load_usage_entries_parallel());
                     let filtered_entries = filter.filter_stream(entries).await;
                     let daily_data = aggregator
-                        .aggregate_daily_verbose(filtered_entries, mode, verbose)
+                        .aggregate_daily_verbose(filtered_entries, mode, detailed)
                         .await?;
                     let totals = Totals::from_daily(&daily_data);
                     let formatter = get_formatter(json, model_display_args.full_model_names);

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use ccstat::{
     data_loader::DataLoader,
     error::Result,
     filters::{MonthFilter, UsageFilter},
-    live_monitor::LiveMonitor,
+    live_monitor::{CommandType, LiveMonitor},
     output::get_formatter,
     pricing_fetcher::PricingFetcher,
     timezone::TimezoneConfig,
@@ -65,19 +65,16 @@ async fn main() -> Result<()> {
     match &cli.command {
         Some(Command::Daily {
             instances,
-            watch,
-            interval,
             detailed,
         }) => {
             info!("Running daily usage report");
 
             let instances = *instances;
-            let watch = *watch;
-            let interval = *interval;
             let detailed = *detailed;
 
             // Initialize components with progress bars enabled for terminal output
-            let show_progress = !cli.json && !watch && is_terminal::is_terminal(std::io::stdout());
+            let show_progress =
+                !cli.json && !cli.watch && is_terminal::is_terminal(std::io::stdout());
             let data_loader =
                 Arc::new(init_data_loader(show_progress, cli.intern, cli.arena).await?);
             let pricing_fetcher = Arc::new(PricingFetcher::new(false).await);
@@ -107,16 +104,20 @@ async fn main() -> Result<()> {
             filter = filter.with_timezone(aggregator.timezone_config().tz);
 
             // Check if we're in watch mode
-            if watch {
+            if cli.watch {
                 info!("Starting live monitoring mode");
                 let monitor = LiveMonitor::new(
                     data_loader,
                     aggregator,
                     filter,
+                    None, // No month filter for daily
                     cli.mode,
                     cli.json,
-                    instances,
-                    interval,
+                    CommandType::Daily {
+                        instances,
+                        detailed,
+                    },
+                    cli.interval,
                     cli.full_model_names,
                 );
                 monitor.run().await?;
@@ -153,16 +154,18 @@ async fn main() -> Result<()> {
             info!("Running monthly usage report");
 
             // Initialize components with progress bars enabled for terminal output
-            let show_progress = !cli.json && is_terminal::is_terminal(std::io::stdout());
-            let data_loader = init_data_loader(show_progress, cli.intern, cli.arena).await?;
+            let show_progress =
+                !cli.json && !cli.watch && is_terminal::is_terminal(std::io::stdout());
+            let data_loader =
+                Arc::new(init_data_loader(show_progress, cli.intern, cli.arena).await?);
             let pricing_fetcher = Arc::new(PricingFetcher::new(false).await);
             let cost_calculator = Arc::new(CostCalculator::new(pricing_fetcher));
-            let aggregator = create_aggregator_with_timezone(
+            let aggregator = Arc::new(create_aggregator_with_timezone(
                 cost_calculator,
                 show_progress,
                 cli.timezone.as_deref(),
                 cli.utc,
-            )?;
+            )?);
 
             // Build month filter
             let mut month_filter = MonthFilter::new();
@@ -176,210 +179,64 @@ async fn main() -> Result<()> {
                 month_filter = month_filter.with_until(until_date.year(), until_date.month());
             }
 
-            // Load entries and aggregate data
-            let entries = Box::pin(data_loader.load_usage_entries_parallel());
-            let daily_data = aggregator.aggregate_daily(entries, cli.mode).await?;
-            let mut monthly_data = Aggregator::aggregate_monthly(&daily_data);
+            // Check if we're in watch mode
+            if cli.watch {
+                info!("Starting live monitoring mode");
+                // Create empty filter for monthly (we'll filter after aggregation)
+                let filter = UsageFilter::new();
+                let monitor = LiveMonitor::new(
+                    data_loader,
+                    aggregator,
+                    filter,
+                    Some(month_filter), // Pass month filter
+                    cli.mode,
+                    cli.json,
+                    CommandType::Monthly,
+                    cli.interval,
+                    cli.full_model_names,
+                );
+                monitor.run().await?;
+            } else {
+                // Load entries and aggregate data
+                let entries = Box::pin(data_loader.load_usage_entries_parallel());
+                let daily_data = aggregator.aggregate_daily(entries, cli.mode).await?;
+                let mut monthly_data = Aggregator::aggregate_monthly(&daily_data);
 
-            // Apply month filter to aggregated monthly data
-            monthly_data.retain(|monthly| {
-                // Parse month string (YYYY-MM) to check filter
-                if let Ok((year, month)) = monthly
-                    .month
-                    .split_once('-')
-                    .and_then(|(y, m)| Some((y.parse::<i32>().ok()?, m.parse::<u32>().ok()?)))
-                    .ok_or(())
-                {
-                    // Create a date for the first day of the month to check filter
-                    if let Some(date) = chrono::NaiveDate::from_ymd_opt(year, month, 1) {
-                        return month_filter.matches_date(&date);
+                // Apply month filter to aggregated monthly data
+                monthly_data.retain(|monthly| {
+                    // Parse month string (YYYY-MM) to check filter
+                    if let Ok((year, month)) = monthly
+                        .month
+                        .split_once('-')
+                        .and_then(|(y, m)| Some((y.parse::<i32>().ok()?, m.parse::<u32>().ok()?)))
+                        .ok_or(())
+                    {
+                        // Create a date for the first day of the month to check filter
+                        if let Some(date) = chrono::NaiveDate::from_ymd_opt(year, month, 1) {
+                            return month_filter.matches_date(&date);
+                        }
                     }
+                    false
+                });
+
+                let mut totals = Totals::default();
+                for monthly in &monthly_data {
+                    totals.tokens += monthly.tokens;
+                    totals.total_cost += monthly.total_cost;
                 }
-                false
-            });
 
-            let mut totals = Totals::default();
-            for monthly in &monthly_data {
-                totals.tokens += monthly.tokens;
-                totals.total_cost += monthly.total_cost;
+                // Format and output
+                let formatter = get_formatter(cli.json, cli.full_model_names);
+                println!("{}", formatter.format_monthly(&monthly_data, &totals));
             }
-
-            // Format and output
-            let formatter = get_formatter(cli.json, cli.full_model_names);
-            println!("{}", formatter.format_monthly(&monthly_data, &totals));
         }
 
         Some(Command::Session) => {
             info!("Running session usage report");
 
             // Initialize components with progress bars enabled for terminal output
-            let show_progress = !cli.json && is_terminal::is_terminal(std::io::stdout());
-            let data_loader = init_data_loader(show_progress, cli.intern, cli.arena).await?;
-            let pricing_fetcher = Arc::new(PricingFetcher::new(false).await);
-            let cost_calculator = Arc::new(CostCalculator::new(pricing_fetcher));
-            let aggregator = create_aggregator_with_timezone(
-                cost_calculator,
-                show_progress,
-                cli.timezone.as_deref(),
-                cli.utc,
-            )?;
-
-            // Build filter
-            let mut filter = UsageFilter::new();
-
-            if let Some(since_str) = &cli.since {
-                let since_date = parse_date_filter(since_str)?;
-                filter = filter.with_since(since_date);
-            }
-            if let Some(until_str) = &cli.until {
-                let until_date = parse_date_filter(until_str)?;
-                filter = filter.with_until(until_date);
-            }
-            if let Some(project_name) = &cli.project {
-                filter = filter.with_project(project_name.clone());
-            }
-            // Apply timezone to filter
-            filter = filter.with_timezone(aggregator.timezone_config().tz);
-
-            // Load, filter and aggregate data
-            let entries = Box::pin(data_loader.load_usage_entries_parallel());
-            let filtered_entries = filter.filter_stream(entries).await;
-            let session_data = aggregator
-                .aggregate_sessions(filtered_entries, cli.mode)
-                .await?;
-            let totals = Totals::from_sessions(&session_data);
-
-            // Format and output
-            let formatter = get_formatter(cli.json, cli.full_model_names);
-            println!(
-                "{}",
-                formatter.format_sessions(&session_data, &totals, &aggregator.timezone_config().tz)
-            );
-        }
-
-        Some(Command::Blocks {
-            active,
-            recent,
-            token_limit,
-        }) => {
-            info!("Running billing blocks report");
-
-            // Initialize components with progress bars enabled for terminal output
-            let show_progress = !cli.json && is_terminal::is_terminal(std::io::stdout());
-            let data_loader = init_data_loader(show_progress, cli.intern, cli.arena).await?;
-            let pricing_fetcher = Arc::new(PricingFetcher::new(false).await);
-            let cost_calculator = Arc::new(CostCalculator::new(pricing_fetcher));
-            let aggregator = create_aggregator_with_timezone(
-                cost_calculator,
-                show_progress,
-                cli.timezone.as_deref(),
-                cli.utc,
-            )?;
-
-            // Load entries and aggregate sessions
-            let entries = Box::pin(data_loader.load_usage_entries_parallel());
-            let session_data = aggregator.aggregate_sessions(entries, cli.mode).await?;
-
-            // Create billing blocks
-            let mut blocks = Aggregator::create_billing_blocks(&session_data);
-
-            // Apply filters
-            if *active {
-                blocks.retain(|b| b.is_active);
-            }
-
-            if *recent {
-                let cutoff = chrono::Utc::now() - chrono::Duration::days(1);
-                blocks.retain(|b| b.start_time > cutoff);
-            }
-
-            // Apply token limit warnings
-            if let Some(limit_str) = token_limit {
-                // Parse token limit (can be a number or percentage like "80%")
-                let (limit_value, is_percentage) = if limit_str.ends_with('%') {
-                    let value = limit_str
-                        .trim_end_matches('%')
-                        .parse::<f64>()
-                        .map_err(|_| {
-                            ccstat::error::CcstatError::InvalidDate(format!(
-                                "Invalid token limit: {limit_str}"
-                            ))
-                        })?;
-                    (value / 100.0, true)
-                } else {
-                    let value = limit_str.parse::<u64>().map_err(|_| {
-                        ccstat::error::CcstatError::InvalidDate(format!(
-                            "Invalid token limit: {limit_str}"
-                        ))
-                    })?;
-                    (value as f64, false)
-                };
-
-                // Apply warnings to blocks
-                for block in &mut blocks {
-                    if block.is_active {
-                        let total_tokens = block.tokens.total();
-                        let threshold = if is_percentage {
-                            // Assuming 5-hour block has a typical max of ~10M tokens
-                            10_000_000.0 * limit_value
-                        } else {
-                            limit_value
-                        };
-
-                        if total_tokens as f64 >= threshold {
-                            block.warning = Some(format!(
-                                "⚠️  Block has used {} tokens, exceeding threshold of {}",
-                                total_tokens,
-                                if is_percentage {
-                                    format!(
-                                        "{}% (~{:.0} tokens)",
-                                        (limit_value * 100.0) as u32,
-                                        threshold
-                                    )
-                                } else {
-                                    format!("{} tokens", threshold as u64)
-                                }
-                            ));
-                        } else if total_tokens as f64 >= threshold * 0.8 {
-                            block.warning = Some(format!(
-                                "⚠️  Block approaching limit: {} tokens used ({}% of threshold)",
-                                total_tokens,
-                                ((total_tokens as f64 / threshold) * 100.0) as u32
-                            ));
-                        }
-                    }
-                }
-            }
-
-            // Format and output
-            let formatter = get_formatter(cli.json, cli.full_model_names);
-            println!(
-                "{}",
-                formatter.format_blocks(&blocks, &aggregator.timezone_config().tz)
-            );
-        }
-
-        Some(Command::Statusline {
-            monthly_fee,
-            no_color,
-            show_date,
-            show_git,
-        }) => {
-            // Run statusline handler
-            ccstat::statusline::run(*monthly_fee, *no_color, *show_date, *show_git).await?;
-        }
-
-        None => {
-            // Default to daily report
-            info!("No command specified, running daily report");
-
-            let _instances = false;
-            let watch = false;
-            let _interval = 5;
-            let detailed = false;
-
-            // Initialize components with progress bars enabled for terminal output
-            let show_progress = !cli.json && !watch && is_terminal::is_terminal(std::io::stdout());
+            let show_progress =
+                !cli.json && !cli.watch && is_terminal::is_terminal(std::io::stdout());
             let data_loader =
                 Arc::new(init_data_loader(show_progress, cli.intern, cli.arena).await?);
             let pricing_fetcher = Arc::new(PricingFetcher::new(false).await);
@@ -408,15 +265,247 @@ async fn main() -> Result<()> {
             // Apply timezone to filter
             filter = filter.with_timezone(aggregator.timezone_config().tz);
 
-            // Load and filter entries, then aggregate normally
-            let entries = Box::pin(data_loader.load_usage_entries_parallel());
-            let filtered_entries = filter.filter_stream(entries).await;
-            let daily_data = aggregator
-                .aggregate_daily_detailed(filtered_entries, cli.mode, detailed)
-                .await?;
-            let totals = Totals::from_daily(&daily_data);
-            let formatter = get_formatter(cli.json, cli.full_model_names);
-            println!("{}", formatter.format_daily(&daily_data, &totals));
+            // Check if we're in watch mode
+            if cli.watch {
+                info!("Starting live monitoring mode");
+                let monitor = LiveMonitor::new(
+                    data_loader,
+                    aggregator.clone(),
+                    filter,
+                    None, // No month filter for sessions
+                    cli.mode,
+                    cli.json,
+                    CommandType::Session,
+                    cli.interval,
+                    cli.full_model_names,
+                );
+                monitor.run().await?;
+            } else {
+                // Load, filter and aggregate data
+                let entries = Box::pin(data_loader.load_usage_entries_parallel());
+                let filtered_entries = filter.filter_stream(entries).await;
+                let session_data = aggregator
+                    .aggregate_sessions(filtered_entries, cli.mode)
+                    .await?;
+                let totals = Totals::from_sessions(&session_data);
+
+                // Format and output
+                let formatter = get_formatter(cli.json, cli.full_model_names);
+                println!(
+                    "{}",
+                    formatter.format_sessions(
+                        &session_data,
+                        &totals,
+                        &aggregator.timezone_config().tz
+                    )
+                );
+            }
+        }
+
+        Some(Command::Blocks {
+            active,
+            recent,
+            token_limit,
+        }) => {
+            info!("Running billing blocks report");
+
+            // Initialize components with progress bars enabled for terminal output
+            let show_progress =
+                !cli.json && !cli.watch && is_terminal::is_terminal(std::io::stdout());
+            let data_loader =
+                Arc::new(init_data_loader(show_progress, cli.intern, cli.arena).await?);
+            let pricing_fetcher = Arc::new(PricingFetcher::new(false).await);
+            let cost_calculator = Arc::new(CostCalculator::new(pricing_fetcher));
+            let aggregator = Arc::new(create_aggregator_with_timezone(
+                cost_calculator,
+                show_progress,
+                cli.timezone.as_deref(),
+                cli.utc,
+            )?);
+
+            // Check if we're in watch mode
+            if cli.watch {
+                info!("Starting live monitoring mode");
+                let filter = UsageFilter::new(); // No filters for blocks at the entry level
+                let monitor = LiveMonitor::new(
+                    data_loader,
+                    aggregator,
+                    filter,
+                    None, // No month filter for blocks
+                    cli.mode,
+                    cli.json,
+                    CommandType::Blocks {
+                        active: *active,
+                        recent: *recent,
+                        token_limit: token_limit.clone(),
+                    },
+                    cli.interval,
+                    cli.full_model_names,
+                );
+                monitor.run().await?;
+            } else {
+                // Load entries and aggregate sessions
+                let entries = Box::pin(data_loader.load_usage_entries_parallel());
+                let session_data = aggregator.aggregate_sessions(entries, cli.mode).await?;
+
+                // Create billing blocks
+                let mut blocks = Aggregator::create_billing_blocks(&session_data);
+
+                // Apply filters
+                if *active {
+                    blocks.retain(|b| b.is_active);
+                }
+
+                if *recent {
+                    let cutoff = chrono::Utc::now() - chrono::Duration::days(1);
+                    blocks.retain(|b| b.start_time > cutoff);
+                }
+
+                // Apply token limit warnings
+                if let Some(limit_str) = token_limit {
+                    // Parse token limit (can be a number or percentage like "80%")
+                    let (limit_value, is_percentage) = if limit_str.ends_with('%') {
+                        let value =
+                            limit_str
+                                .trim_end_matches('%')
+                                .parse::<f64>()
+                                .map_err(|_| {
+                                    ccstat::error::CcstatError::InvalidDate(format!(
+                                        "Invalid token limit: {limit_str}"
+                                    ))
+                                })?;
+                        (value / 100.0, true)
+                    } else {
+                        let value = limit_str.parse::<u64>().map_err(|_| {
+                            ccstat::error::CcstatError::InvalidDate(format!(
+                                "Invalid token limit: {limit_str}"
+                            ))
+                        })?;
+                        (value as f64, false)
+                    };
+
+                    // Apply warnings to blocks
+                    for block in &mut blocks {
+                        if block.is_active {
+                            let total_tokens = block.tokens.total();
+                            let threshold = if is_percentage {
+                                // Assuming 5-hour block has a typical max of ~10M tokens
+                                10_000_000.0 * limit_value
+                            } else {
+                                limit_value
+                            };
+
+                            if total_tokens as f64 >= threshold {
+                                block.warning = Some(format!(
+                                    "⚠️  Block has used {} tokens, exceeding threshold of {}",
+                                    total_tokens,
+                                    if is_percentage {
+                                        format!(
+                                            "{}% (~{:.0} tokens)",
+                                            (limit_value * 100.0) as u32,
+                                            threshold
+                                        )
+                                    } else {
+                                        format!("{} tokens", threshold as u64)
+                                    }
+                                ));
+                            } else if total_tokens as f64 >= threshold * 0.8 {
+                                block.warning = Some(format!(
+                                    "⚠️  Block approaching limit: {} tokens used ({}% of threshold)",
+                                    total_tokens,
+                                    ((total_tokens as f64 / threshold) * 100.0) as u32
+                                ));
+                            }
+                        }
+                    }
+                }
+
+                // Format and output
+                let formatter = get_formatter(cli.json, cli.full_model_names);
+                println!(
+                    "{}",
+                    formatter.format_blocks(&blocks, &aggregator.timezone_config().tz)
+                );
+            }
+        }
+
+        Some(Command::Statusline {
+            monthly_fee,
+            no_color,
+            show_date,
+            show_git,
+        }) => {
+            // Run statusline handler
+            ccstat::statusline::run(*monthly_fee, *no_color, *show_date, *show_git).await?;
+        }
+
+        None => {
+            // Default to daily report
+            info!("No command specified, running daily report");
+
+            let instances = false;
+            let detailed = false;
+
+            // Initialize components with progress bars enabled for terminal output
+            let show_progress =
+                !cli.json && !cli.watch && is_terminal::is_terminal(std::io::stdout());
+            let data_loader =
+                Arc::new(init_data_loader(show_progress, cli.intern, cli.arena).await?);
+            let pricing_fetcher = Arc::new(PricingFetcher::new(false).await);
+            let cost_calculator = Arc::new(CostCalculator::new(pricing_fetcher));
+            let aggregator = Arc::new(create_aggregator_with_timezone(
+                cost_calculator,
+                show_progress,
+                cli.timezone.as_deref(),
+                cli.utc,
+            )?);
+
+            // Build filter
+            let mut filter = UsageFilter::new();
+
+            if let Some(since_str) = &cli.since {
+                let since_date = parse_date_filter(since_str)?;
+                filter = filter.with_since(since_date);
+            }
+            if let Some(until_str) = &cli.until {
+                let until_date = parse_date_filter(until_str)?;
+                filter = filter.with_until(until_date);
+            }
+            if let Some(project_name) = &cli.project {
+                filter = filter.with_project(project_name.clone());
+            }
+            // Apply timezone to filter
+            filter = filter.with_timezone(aggregator.timezone_config().tz);
+
+            // Check if we're in watch mode
+            if cli.watch {
+                info!("Starting live monitoring mode");
+                let monitor = LiveMonitor::new(
+                    data_loader,
+                    aggregator,
+                    filter,
+                    None, // No month filter for daily
+                    cli.mode,
+                    cli.json,
+                    CommandType::Daily {
+                        instances,
+                        detailed,
+                    },
+                    cli.interval,
+                    cli.full_model_names,
+                );
+                monitor.run().await?;
+            } else {
+                // Load and filter entries, then aggregate normally
+                let entries = Box::pin(data_loader.load_usage_entries_parallel());
+                let filtered_entries = filter.filter_stream(entries).await;
+                let daily_data = aggregator
+                    .aggregate_daily_detailed(filtered_entries, cli.mode, detailed)
+                    .await?;
+                let totals = Totals::from_daily(&daily_data);
+                let formatter = get_formatter(cli.json, cli.full_model_names);
+                println!("{}", formatter.format_daily(&daily_data, &totals));
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,27 +40,10 @@ async fn init_data_loader(show_progress: bool, intern: bool, arena: bool) -> Res
         .with_arena(arena))
 }
 
-/// Helper function to check for deprecated flags and show warnings
-fn check_deprecated_flags(cli: &Cli) {
-    if cli.quiet {
-        eprintln!("Warning: --quiet flag is deprecated and will be removed in v0.3.0");
-        eprintln!(
-            "         Quiet mode is now the default behavior. Use --verbose to show informational output."
-        );
-    }
-    if !cli.parallel {
-        eprintln!("Warning: --parallel=false flag is deprecated and will be removed in v0.3.0");
-        eprintln!("         Parallel processing is now always enabled for better performance.");
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Parse CLI arguments first to check for quiet flag
+    // Parse CLI arguments
     let cli = Cli::parse();
-
-    // Check for deprecated flags early
-    check_deprecated_flags(&cli);
 
     // Skip logging initialization for statusline command
     let is_statusline = matches!(cli.command, Some(Command::Statusline { .. }));

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,13 @@ async fn main() -> Result<()> {
     // Check for deprecated global flags early
     check_deprecated_global_flags(&cli);
 
+    // Check for deprecated command-specific flags
+    if let Some(command) = &cli.command
+        && let Some(perf_args) = command.performance_args()
+    {
+        check_deprecated_perf_flags(perf_args);
+    }
+
     // Skip logging initialization for statusline command
     let is_statusline = matches!(cli.command, Some(Command::Statusline { .. }));
 
@@ -100,7 +107,6 @@ async fn main() -> Result<()> {
             timezone_args,
         }) => {
             info!("Running daily usage report");
-            check_deprecated_perf_flags(&performance_args);
 
             // Initialize components with progress bars enabled for terminal output
             let show_progress = !json && !watch && is_terminal::is_terminal(std::io::stdout());
@@ -164,7 +170,7 @@ async fn main() -> Result<()> {
                     let entries = Box::pin(data_loader.load_usage_entries_parallel());
                     let filtered_entries = filter.filter_stream(entries).await;
                     let daily_data = aggregator
-                        .aggregate_daily_verbose(filtered_entries, mode, detailed)
+                        .aggregate_daily_detailed(filtered_entries, mode, detailed)
                         .await?;
                     let totals = Totals::from_daily(&daily_data);
                     let formatter = get_formatter(json, model_display_args.full_model_names);
@@ -183,7 +189,6 @@ async fn main() -> Result<()> {
             timezone_args,
         }) => {
             info!("Running monthly usage report");
-            check_deprecated_perf_flags(&performance_args);
 
             // Initialize components with progress bars enabled for terminal output
             let show_progress = !json && is_terminal::is_terminal(std::io::stdout());
@@ -248,7 +253,6 @@ async fn main() -> Result<()> {
             timezone_args,
         }) => {
             info!("Running session usage report");
-            check_deprecated_perf_flags(&performance_args);
 
             // Initialize components with progress bars enabled for terminal output
             let show_progress = !json && is_terminal::is_terminal(std::io::stdout());
@@ -299,7 +303,6 @@ async fn main() -> Result<()> {
             timezone_args,
         }) => {
             info!("Running billing blocks report");
-            check_deprecated_perf_flags(&performance_args);
 
             // Initialize components with progress bars enabled for terminal output
             let show_progress = !json && is_terminal::is_terminal(std::io::stdout());

--- a/tests/commands_test.rs
+++ b/tests/commands_test.rs
@@ -6,15 +6,9 @@
 mod common;
 
 use ccstat::{
-    aggregation::Aggregator,
-    cli::parse_date_filter,
-    cost_calculator::CostCalculator,
-    data_loader::DataLoader,
-    filters::UsageFilter,
-    output::get_formatter,
-    pricing_fetcher::PricingFetcher,
-    timezone::TimezoneConfig,
-    types::CostMode,
+    aggregation::Aggregator, cli::parse_date_filter, cost_calculator::CostCalculator,
+    data_loader::DataLoader, filters::UsageFilter, output::get_formatter,
+    pricing_fetcher::PricingFetcher, timezone::TimezoneConfig, types::CostMode,
 };
 use chrono::{Datelike, NaiveDate};
 use futures::StreamExt;
@@ -238,7 +232,7 @@ async fn test_date_filter_parsing() {
 #[tokio::test]
 async fn test_month_filter_parsing() {
     use chrono::Datelike;
-    
+
     // Test valid month formats (YYYY-MM should parse to first day of month)
     let date = parse_date_filter("2024-01").unwrap();
     assert_eq!(date.year(), 2024);

--- a/tests/commands_test.rs
+++ b/tests/commands_test.rs
@@ -7,7 +7,7 @@ mod common;
 
 use ccstat::{
     aggregation::Aggregator,
-    cli::{parse_date_filter, parse_month_filter},
+    cli::parse_date_filter,
     cost_calculator::CostCalculator,
     data_loader::DataLoader,
     filters::UsageFilter,
@@ -237,20 +237,24 @@ async fn test_date_filter_parsing() {
 
 #[tokio::test]
 async fn test_month_filter_parsing() {
-    // Test valid month formats
-    let (year, month) = parse_month_filter("2024-01").unwrap();
-    assert_eq!(year, 2024);
-    assert_eq!(month, 1);
+    use chrono::Datelike;
+    
+    // Test valid month formats (YYYY-MM should parse to first day of month)
+    let date = parse_date_filter("2024-01").unwrap();
+    assert_eq!(date.year(), 2024);
+    assert_eq!(date.month(), 1);
+    assert_eq!(date.day(), 1);
 
-    let (year, month) = parse_month_filter("2024-12").unwrap();
-    assert_eq!(year, 2024);
-    assert_eq!(month, 12);
+    let date = parse_date_filter("2024-12").unwrap();
+    assert_eq!(date.year(), 2024);
+    assert_eq!(date.month(), 12);
+    assert_eq!(date.day(), 1);
 
     // Test invalid month format
-    assert!(parse_month_filter("2024").is_err());
-    assert!(parse_month_filter("2024-13").is_err());
-    assert!(parse_month_filter("2024-00").is_err());
-    assert!(parse_month_filter("invalid").is_err());
+    assert!(parse_date_filter("2024").is_err());
+    assert!(parse_date_filter("2024-13").is_err());
+    assert!(parse_date_filter("2024-00").is_err());
+    assert!(parse_date_filter("invalid").is_err());
 }
 
 #[tokio::test]

--- a/tests/end_to_end_test.rs
+++ b/tests/end_to_end_test.rs
@@ -7,7 +7,7 @@ mod common;
 
 use ccstat::{
     aggregation::Aggregator,
-    cli::{parse_date_filter, parse_month_filter},
+    cli::parse_date_filter,
     cost_calculator::CostCalculator,
     data_loader::DataLoader,
     error::CcstatError,
@@ -430,7 +430,7 @@ async fn test_error_handling_workflow() {
     let result = parse_date_filter("not-a-date");
     assert!(result.is_err());
 
-    let result = parse_month_filter("2024-13"); // Invalid month
+    let result = parse_date_filter("2024-13"); // Invalid month
     assert!(result.is_err());
 
     // Test with non-existent data directory - use mutex for thread safety

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -578,7 +578,7 @@ async fn test_error_handling() {
     }
 
     // Test with invalid month filter
-    let result = ccstat::cli::parse_month_filter("2024-13");
+    let result = ccstat::cli::parse_date_filter("2024-13");
     assert!(result.is_err());
     match result {
         Err(CcstatError::InvalidDate(_)) => {}

--- a/tests/proptest_test.rs
+++ b/tests/proptest_test.rs
@@ -251,12 +251,13 @@ proptest! {
         month in 1u32..=12,
     ) {
         let month_str = format!("{year:04}-{month:02}");
-        let result = ccstat::cli::parse_month_filter(&month_str);
+        let result = ccstat::cli::parse_date_filter(&month_str);
         prop_assert!(result.is_ok());
 
-        let (parsed_year, parsed_month) = result.unwrap();
-        prop_assert_eq!(parsed_year, year);
-        prop_assert_eq!(parsed_month, month);
+        let parsed_date = result.unwrap();
+        prop_assert_eq!(parsed_date.year(), year);
+        prop_assert_eq!(parsed_date.month(), month);
+        prop_assert_eq!(parsed_date.day(), 1); // Should default to first day
     }
 }
 


### PR DESCRIPTION
- Quiet mode is now the default behavior (only warnings/errors shown)
- Added global --verbose/-v flag to enable informational output
- Deprecated --quiet/-q flag (will be removed in v0.3.0)
- Updated documentation to reflect new logging behavior

BREAKING CHANGE: Default behavior changed from showing info messages to quiet mode. Use --verbose to see informational output.

🤖 Generated with [Claude Code](https://claude.ai/code)