### PR TITLE
feat: add --entries flag to blocks command for detailed session display

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -126,6 +126,10 @@ pub enum Command {
         /// Token limit for warnings
         #[arg(long)]
         token_limit: Option<String>,
+
+        /// Show individual session entries within each block
+        #[arg(long)]
+        entries: bool,
     },
 
     /// Generate statusline output for Claude Code

--- a/src/live_monitor.rs
+++ b/src/live_monitor.rs
@@ -53,6 +53,7 @@ pub enum CommandType {
         active: bool,
         recent: bool,
         token_limit: Option<String>,
+        entries: bool,
     },
 }
 
@@ -356,6 +357,7 @@ impl LiveMonitor {
                 active,
                 recent,
                 token_limit,
+                entries: _,
             } => {
                 // First aggregate sessions, then create blocks
                 let session_data = self.aggregate_sessions_for_watch(&filtered_entries).await?;
@@ -473,11 +475,15 @@ impl LiveMonitor {
                     );
                 }
             }
-            CommandType::Blocks { .. } => {
+            CommandType::Blocks { entries, .. } => {
                 if let Some(ref blocks_data) = prepared_data.blocks_data {
                     println!(
                         "{}",
-                        formatter.format_blocks(blocks_data, &self.aggregator.timezone_config().tz)
+                        formatter.format_blocks(
+                            blocks_data,
+                            &self.aggregator.timezone_config().tz,
+                            *entries
+                        )
                     );
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -221,6 +221,7 @@ async fn main() -> Result<()> {
             active,
             recent,
             token_limit,
+            entries,
         }) => {
             info!("Running billing blocks report");
 
@@ -255,6 +256,7 @@ async fn main() -> Result<()> {
                         active: *active,
                         recent: *recent,
                         token_limit: token_limit.clone(),
+                        entries: *entries,
                     },
                     cli.interval,
                     cli.full_model_names,
@@ -262,8 +264,8 @@ async fn main() -> Result<()> {
                 monitor.run().await?;
             } else {
                 // Load and filter entries, then aggregate sessions
-                let entries = Box::pin(data_loader.load_usage_entries_parallel());
-                let filtered_entries = filter.filter_stream(entries).await;
+                let usage_entries = Box::pin(data_loader.load_usage_entries_parallel());
+                let filtered_entries = filter.filter_stream(usage_entries).await;
                 let session_data = aggregator
                     .aggregate_sessions(filtered_entries, cli.mode)
                     .await?;
@@ -287,7 +289,7 @@ async fn main() -> Result<()> {
                 let formatter = get_formatter(cli.json, cli.full_model_names);
                 println!(
                     "{}",
-                    formatter.format_blocks(&blocks, &aggregator.timezone_config().tz)
+                    formatter.format_blocks(&blocks, &aggregator.timezone_config().tz, *entries)
                 );
             }
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -70,7 +70,7 @@ use serde_json::json;
 ///         format!("Total months: {}", data.len())
 ///     }
 ///
-///     fn format_blocks(&self, data: &[SessionBlock], _tz: &chrono_tz::Tz) -> String {
+///     fn format_blocks(&self, data: &[SessionBlock], _tz: &chrono_tz::Tz, _show_entries: bool) -> String {
 ///         format!("Total blocks: {}", data.len())
 ///     }
 /// }
@@ -90,7 +90,12 @@ pub trait OutputFormatter {
     fn format_monthly(&self, data: &[MonthlyUsage], totals: &Totals) -> String;
 
     /// Format billing blocks (5-hour windows)
-    fn format_blocks(&self, data: &[SessionBlock], tz: &chrono_tz::Tz) -> String;
+    fn format_blocks(
+        &self,
+        data: &[SessionBlock],
+        tz: &chrono_tz::Tz,
+        show_entries: bool,
+    ) -> String;
 }
 
 /// Table formatter for human-readable output
@@ -154,6 +159,7 @@ impl TableFormatter {
         data: &[SessionBlock],
         tz: &chrono_tz::Tz,
         now: chrono::DateTime<chrono::Utc>,
+        show_entries: bool,
     ) -> String {
         let mut table = Table::new();
         table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
@@ -202,6 +208,37 @@ impl TableFormatter {
                 r -> Self::format_currency(block.total_cost),
                 time_remaining
             ]);
+
+            // Show individual session entries if requested
+            if show_entries && !block.sessions.is_empty() {
+                for session in &block.sessions {
+                    let session_start = Self::format_datetime_with_tz(&session.start_time, tz);
+                    let session_end = session
+                        .end_time
+                        .with_timezone(tz)
+                        .format("%H:%M")
+                        .to_string();
+                    let duration = session.end_time - session.start_time;
+                    let duration_str = format!("{}m", duration.num_minutes());
+
+                    let model_name = if self.full_model_names {
+                        session.model.to_string()
+                    } else {
+                        crate::model_formatter::format_model_name(&session.model.to_string(), false)
+                    };
+
+                    table.add_row(row![
+                        format!("  └─ {}-{}", session_start, session_end),
+                        duration_str,
+                        session.session_id.as_str(),
+                        r -> Self::format_number(session.tokens.input_tokens),
+                        r -> Self::format_number(session.tokens.output_tokens),
+                        r -> Self::format_number(session.tokens.total()),
+                        r -> Self::format_currency(session.total_cost),
+                        model_name
+                    ]);
+                }
+            }
         }
 
         table.to_string()
@@ -447,8 +484,13 @@ impl OutputFormatter for TableFormatter {
         table.to_string()
     }
 
-    fn format_blocks(&self, data: &[SessionBlock], tz: &chrono_tz::Tz) -> String {
-        self.format_blocks_with_now(data, tz, chrono::Utc::now())
+    fn format_blocks(
+        &self,
+        data: &[SessionBlock],
+        tz: &chrono_tz::Tz,
+        show_entries: bool,
+    ) -> String {
+        self.format_blocks_with_now(data, tz, chrono::Utc::now(), show_entries)
     }
 }
 
@@ -606,23 +648,51 @@ impl OutputFormatter for JsonFormatter {
         serde_json::to_string_pretty(&output).unwrap()
     }
 
-    fn format_blocks(&self, data: &[SessionBlock], _tz: &chrono_tz::Tz) -> String {
+    fn format_blocks(
+        &self,
+        data: &[SessionBlock],
+        _tz: &chrono_tz::Tz,
+        show_entries: bool,
+    ) -> String {
         let output = json!({
-            "blocks": data.iter().map(|b| json!({
-                "start_time": b.start_time.to_rfc3339(),
-                "end_time": b.end_time.to_rfc3339(),
-                "is_active": b.is_active,
-                "session_count": b.sessions.len(),
-                "tokens": {
-                    "input_tokens": b.tokens.input_tokens,
-                    "output_tokens": b.tokens.output_tokens,
-                    "cache_creation_tokens": b.tokens.cache_creation_tokens,
-                    "cache_read_tokens": b.tokens.cache_read_tokens,
-                    "total": b.tokens.total(),
-                },
-                "total_cost": b.total_cost,
-                "sessions": b.sessions.iter().map(|s| s.session_id.as_str()).collect::<Vec<_>>(),
-            })).collect::<Vec<_>>()
+            "blocks": data.iter().map(|b| {
+                let mut block_json = json!({
+                    "start_time": b.start_time.to_rfc3339(),
+                    "end_time": b.end_time.to_rfc3339(),
+                    "is_active": b.is_active,
+                    "session_count": b.sessions.len(),
+                    "tokens": {
+                        "input_tokens": b.tokens.input_tokens,
+                        "output_tokens": b.tokens.output_tokens,
+                        "cache_creation_tokens": b.tokens.cache_creation_tokens,
+                        "cache_read_tokens": b.tokens.cache_read_tokens,
+                        "total": b.tokens.total(),
+                    },
+                    "total_cost": b.total_cost,
+                });
+
+                // Include full session details if requested, otherwise just session IDs
+                if show_entries {
+                    block_json["sessions"] = json!(b.sessions.iter().map(|s| json!({
+                        "session_id": s.session_id.as_str(),
+                        "start_time": s.start_time.to_rfc3339(),
+                        "end_time": s.end_time.to_rfc3339(),
+                        "model": s.model.to_string(),
+                        "tokens": {
+                            "input_tokens": s.tokens.input_tokens,
+                            "output_tokens": s.tokens.output_tokens,
+                            "cache_creation_tokens": s.tokens.cache_creation_tokens,
+                            "cache_read_tokens": s.tokens.cache_read_tokens,
+                            "total": s.tokens.total(),
+                        },
+                        "total_cost": s.total_cost,
+                    })).collect::<Vec<_>>());
+                } else {
+                    block_json["sessions"] = json!(b.sessions.iter().map(|s| s.session_id.as_str()).collect::<Vec<_>>());
+                }
+
+                block_json
+            }).collect::<Vec<_>>()
         });
 
         serde_json::to_string_pretty(&output).unwrap()
@@ -958,7 +1028,7 @@ mod tests {
         };
 
         let blocks = vec![active_block, expired_block];
-        let output = formatter.format_blocks_with_now(&blocks, &tz, now);
+        let output = formatter.format_blocks_with_now(&blocks, &tz, now, false);
 
         assert!(output.contains("ACTIVE"));
         assert!(output.contains("Complete"));
@@ -1091,7 +1161,7 @@ mod tests {
         };
 
         let blocks = vec![block];
-        let output = formatter.format_blocks(&blocks, &tz);
+        let output = formatter.format_blocks(&blocks, &tz, false);
 
         let json: serde_json::Value =
             serde_json::from_str(&output).expect("Failed to parse JSON output");


### PR DESCRIPTION
Added new --entries option to the blocks command that shows individual session details within each 5-hour billing block. This provides users with full visibility into what's happening within each block.

Changes:
- Add --entries CLI flag to blocks command
- Update CommandType enum to include entries field
- Enhance table formatter to display session details including:
  - Session time range and duration
  - Session ID and model used
  - Token counts breakdown (input, output, cache)
  - Cost per session
- Enhance JSON formatter to include full session objects when entries flag is set
- Maintain backward compatibility (default behavior unchanged)

🤖 Generated with [Claude Code](https://claude.ai/code)