### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2025-08-15
+
+### Fixed
+- Properly count sessions in billing blocks
+- Improve format_duration robustness and remove redundant output
+- Handle negative session duration to prevent panic
+- Correct gap block creation logic
+
 ## [0.3.1] - 2025-08-14
 
 ### Fixed
@@ -174,7 +182,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Advanced filtering options by date, project, and instance
 - High-performance stream processing with minimal memory footprint
 
-[Unreleased]: https://github.com/hydai/ccstat/compare/v0.2.2...HEAD
+[Unreleased]: https://github.com/hydai/ccstat/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/hydai/ccstat/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/hydai/ccstat/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/hydai/ccstat/compare/v0.2.2...v0.3.0
 [0.2.2]: https://github.com/hydai/ccstat/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/hydai/ccstat/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/hydai/ccstat/compare/v0.1.9...v0.2.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ No command-specific options. Uses all global options.
 - Example usage: `echo '{"session_id": "test", "model": {"id": "claude-3-opus", "display_name": "Claude 3 Opus"}}' | ccstat statusline`
 
 ## Important Notes
-- Current version: 0.3.1
+- Current version: 0.3.2
 - The project requires Rust 1.75 or later
 - Dependencies are managed in `ccusage/Cargo.toml`
 - Tests are co-located with source files

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "ccstat"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccstat"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 authors = ["hydai"]
 description = "Analyze Claude Code usage data from local JSONL files"


### PR DESCRIPTION
Update version across all project files:
- Cargo.toml: 0.3.1 -> 0.3.2
- CLAUDE.md: Update version reference
- CHANGELOG.md: Add v0.3.2 entry with recent fixes
- Cargo.lock: Update package version

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bump project version to 0.3.2 across metadata, documentation, and lock file.

Documentation:
- Add changelog entry for v0.3.2 with recent fixes and update comparison links
- Update version reference in CLAUDE.md to 0.3.2

Chores:
- Bump version to 0.3.2 in Cargo.toml and Cargo.lock